### PR TITLE
Update scripts and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.csm
 *.gil
 *.log
+*.deps
 klee_build

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ bug fixes detailed above and corresponds to the Collections-C repo at commit [58
 $ ./runGillianTests.sh
 ```
 
-Finally, both version of the library in this repo have had to be modified
-slightly in order to account for the current limitation of Gillian-C. These
-consist of:
+Finally, both versions of the library in this repo have had to be modified
+slightly in order to account for the current limitations of Gillian-C. The changes are:
 
 - The redefinition of the `CC_MAX_ELEMENTS` macro (in `include/common.h`) from 
   `((size_t) - 2)` to `16777216LU` (i.e. 2 ^ 24), as casts are not yet supported
@@ -32,19 +31,18 @@ consist of:
 - The removal of the `#include <stdio.h>` directive from `include/ring_buffer.h`,
   as Gillian does not yet support all standard library functions.
 
-
 ## Running examples with KLEE
 
 Make sure that Klee, as well as `clang` and `llvm-link` is installed globally on your machine.
-You also need the `klee_src` folder that contains `include/klee/klee.h` to be next to the collections-c-for-gillian folder.
+You also need the `klee_src` folder that contains `include/klee/klee.h` to be next to the `collections-c-for-gillian` folder.
 
-Then, you can run a test suite, such as `array` by running
+Then, you can run a specific test suite (e.g. `array`) using
 
 ```
-$ ./testKleeFolder.sh for-klee/normal/pqueue
+$ ./testKleeFolder.sh for-klee/normal/array
 ```
 
-or 
+or
 
 ```
 $ ./testKleeFolder.sh for-klee/bugs

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project is a fork of [Collections-C](https://github.com/srdja/Collections-C
 It contains the library as well as symbolic tests for it. There are two 
 versions of the library and two corresponding test suites included.
 
+The following instructions were tests with the following Gillian commit : [GillianPlatform/Gillian@b3ab5d2](https://github.com/GillianPlatform/Gillian/commit/b3ab5d2c335bcab4768e755276d62357f4e60670)
+
 The first can be found under `lib-with-bugs`, and contains the library 
 without the bug fixes that are detailed in the Gillian-C [documentation](https://gillianplatform.github.io/docs/c/cstest/). This corresponds to the Collections-C repo at commit [82878fd](https://github.com/srdja/Collections-C/tree/82878fd92a4586e7f2b1e476be335441f07ca92f), after accounting for only the files
 that are relevant to the tests. The tests for this version 

--- a/clean.sh
+++ b/clean.sh
@@ -5,6 +5,7 @@ set -e
 find . -name \*.csm -type f -delete
 find . -name \*.i -type f -delete
 find . -name \*.gil -type f -delete
+find . -name \*.deps -type f -delete
 rm -f *.log
 
 find . -name \*.bc -type f -delete

--- a/runGillianTestsParallel.sh
+++ b/runGillianTestsParallel.sh
@@ -19,10 +19,10 @@ for filename in ${TESTS_DIR}/**/*.c; do
     if [[ "${ENABLE_STATS}" = "--stats" ]]; then
         time gillian-c wpst ${filename} -I ${LIB_HEADERS_DIR} \
             -I ${UTILS_HEADERS_DIR} -S ${LIB_SRC_DIR} -S ${UTILS_SRC_DIR} \
-            --ignore-undef -s --stats
+            --ignore-undef -l disabled --parallel --stats
     else
         time gillian-c wpst ${filename} -I ${LIB_HEADERS_DIR} \
             -I ${UTILS_HEADERS_DIR} -S ${LIB_SRC_DIR} -S ${UTILS_SRC_DIR} \
-            --ignore-undef -s --parallel
+            --ignore-undef -l disabled --parallel
     fi
 done


### PR DESCRIPTION
Ignore and clean the `.deps` files that now get generated during
compilation; use the correct logging CLI; and fix some typos in the
README. Works with https://github.com/GillianPlatform/Gillian/commit/b3ab5d2c335bcab4768e755276d62357f4e60670.